### PR TITLE
Implement basic AI client service

### DIFF
--- a/Pages/Index.cshtml
+++ b/Pages/Index.cshtml
@@ -2,10 +2,14 @@
 @model IndexModel
 
 <form method="post">
-    <input type="text" name="query" placeholder="Enter your query" />
+    <input type="text" asp-for="Query" placeholder="Enter your query" />
     <button type="submit">Submit</button>
 </form>
 
-<ul id="results">
-    <li><a href="#" target="_blank">Example result</a></li>
-</ul>
+@if (Model.Result != null)
+{
+    <div id="results">
+        <p>@Model.Result</p>
+    </div>
+}
+

--- a/Pages/Index.cshtml.cs
+++ b/Pages/Index.cshtml.cs
@@ -1,0 +1,27 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using SmartNavigator.Services;
+using System.Threading.Tasks;
+
+public class IndexModel : PageModel
+{
+    private readonly AiClient _client;
+
+    public IndexModel(AiClient client)
+    {
+        _client = client;
+    }
+
+    [BindProperty]
+    public string? Query { get; set; }
+
+    public string? Result { get; set; }
+
+    public async Task OnPostAsync()
+    {
+        if (!string.IsNullOrWhiteSpace(Query))
+        {
+            Result = await _client.QueryAsync(Query);
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
 # SmartNavigator
+
+This sample uses the Hugging Face Inference API to generate answers for user queries.
+
+Set the `HF_TOKEN` environment variable with your free API token before running the app.
+

--- a/Services/AiClient.cs
+++ b/Services/AiClient.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace SmartNavigator.Services
+{
+    public class AiClient
+    {
+        private readonly HttpClient _httpClient;
+        private readonly string _model;
+
+        public AiClient(HttpClient httpClient, string token, string model = "gpt2")
+        {
+            _httpClient = httpClient;
+            _httpClient.BaseAddress = new Uri("https://api-inference.huggingface.co/models/");
+            _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            _model = model;
+        }
+
+        public async Task<string> QueryAsync(string text)
+        {
+            var payload = JsonSerializer.Serialize(new { inputs = text });
+            using var content = new StringContent(payload, Encoding.UTF8, "application/json");
+            using var response = await _httpClient.PostAsync(_model, content);
+            response.EnsureSuccessStatusCode();
+            var json = await response.Content.ReadAsStringAsync();
+            using var doc = JsonDocument.Parse(json);
+            var generated = doc.RootElement[0].GetProperty("generated_text").GetString();
+            return generated ?? string.Empty;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- connect to Hugging Face Inference API
- expose `AiClient` service
- display generated text in the index page
- document API token requirement

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687157c58c6c83219424992b6e473387