### PR TITLE
Add link handling and open main URL

### DIFF
--- a/Pages/Index.cshtml
+++ b/Pages/Index.cshtml
@@ -10,6 +10,26 @@
 {
     <div id="results">
         <p>@Model.Result</p>
+        @if (Model.RelatedUrls != null && Model.RelatedUrls.Any())
+        {
+            <h3>Related URLs</h3>
+            <ul>
+                @foreach (var url in Model.RelatedUrls)
+                {
+                    <li><a href="@url" target="_blank">@url</a></li>
+                }
+            </ul>
+        }
     </div>
 }
 
+@section Scripts {
+    <script>
+        (function () {
+            var mainUrl = "@Model.MainUrl";
+            if (mainUrl) {
+                window.open(mainUrl, "_blank");
+            }
+        })();
+    </script>
+}

--- a/Pages/Index.cshtml.cs
+++ b/Pages/Index.cshtml.cs
@@ -1,6 +1,9 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using SmartNavigator.Services;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
 public class IndexModel : PageModel
@@ -17,11 +20,25 @@ public class IndexModel : PageModel
 
     public string? Result { get; set; }
 
+    public string? MainUrl { get; set; }
+
+    public List<string>? RelatedUrls { get; set; }
+
     public async Task OnPostAsync()
     {
         if (!string.IsNullOrWhiteSpace(Query))
         {
             Result = await _client.QueryAsync(Query);
+
+            if (!string.IsNullOrWhiteSpace(Result))
+            {
+                var matches = Regex.Matches(Result, @"https?://\S+");
+                if (matches.Count > 0)
+                {
+                    MainUrl = matches[0].Value;
+                    RelatedUrls = matches.Cast<Match>().Skip(1).Select(m => m.Value).ToList();
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- parse AI results for the main URL and any related URLs
- display related links on the results page
- auto-open the main URL in a new tab when results load

## Testing
- `dotnet build` *(fails: command not found)*
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6871592964bc832194a37bb5b20fbfc0